### PR TITLE
multiple pushurls for remote

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -25,9 +25,15 @@ function encode (obj, opt) {
   Object.keys(obj).forEach(function (k, _, __) {
     var val = obj[k]
     if (val && Array.isArray(val)) {
-      val.forEach(function (item) {
-        out += safe(k + '[]') + separator + safe(item) + '\n'
-      })
+      if (k === 'pushurl') {
+        val.forEach(function (item) {
+          out += '\t' + safe(k) + separator + safe(item) + '\n'
+        })
+      } else {
+        val.forEach(function (item) {
+          out += safe(k + '[]') + separator + safe(item) + '\n'
+        })
+      }
     } else if (val && typeof val === 'object') {
       children.push(k)
     } else {
@@ -84,6 +90,9 @@ function decode (str) {
       case 'false':
       case 'null': value = JSON.parse(value)
     }
+
+    // Convert pushurl keys to array
+    if (key === 'pushurl') key = 'pushurl[]'
 
     // Convert keys with '[]' suffix to an array
     if (key.length > 2 && key.slice(-2) === '[]') {

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -63,3 +63,10 @@ nocomment = this\; this is not a comment
 
 # this next one is not a comment!  it's escaped!
 noHashComment = this\# this is not a comment
+
+; this overloading is git config format but not standard ini
+[remote "a"]
+url = 1
+pushurl = 2
+pushurl = 3
+pushurl = 4

--- a/test/foo.js
+++ b/test/foo.js
@@ -19,6 +19,11 @@ var i = require("../")
             + 'ar[] = this is included\n'
             + '\tbr = warm\n'
             + '\teq = \"eq=eq\"\n'
+            + '[remote "a"]\n'
+            + '\turl = 1\n'
+            + '\tpushurl = 2\n'
+            + '\tpushurl = 3\n'
+            + '\tpushurl = 4\n'
             + '[a]\n'
             + '\tav = a val\n'
             + '\te = { o: p, a: '
@@ -32,11 +37,13 @@ var i = require("../")
             + '[x\\.y\\.z.a\\.b\\.c]\n\ta.b.c = abc\n'
             + '\tnocomment = this\\; this is not a comment\n'
             + '\tnoHashComment = this\\# this is not a comment\n'
+
   , expectD =
     { o: 'p',
       'a with spaces': 'b  c',
       " xa  n          p ":'"\r\nyoyoyo\r\r\n',
       '[disturbing]': 'hey you never know',
+      'remote "a"': { url: 1, pushurl: [ 2, 3, 4 ] },
       's': 'something',
       's1' : '\"something\'',
       's2': 'something else',


### PR DESCRIPTION
Lets say you have remote `a` with push URLs `1`, `2`, and `3`. The record in `.git/config` would look like this:

```
[remote "a"]
        url = 1
        fetch = +refs/heads/*:refs/remotes/a/*
        pushurl = 2
        pushurl = 3
```

Now this library will treat pushurl as if it was an array, even though git likes to store it like an overloaded string.